### PR TITLE
Fix: typing for findPath and findPathTo

### DIFF
--- a/@types/game/prototypes/room-object.d.ts
+++ b/@types/game/prototypes/room-object.d.ts
@@ -1,5 +1,5 @@
 declare module "game/prototypes" {
-  import { FindPathOpts, FindPathResult, RoomPosition } from "game";
+  import { FindPathOpts, PathStep, RoomPosition } from "game";
   export interface RoomObject extends RoomPosition {
     /**
      * A unique object identificator.
@@ -18,7 +18,7 @@ declare module "game/prototypes" {
      * @param pos
      * @param opts
      */
-    findPathTo(pos: RoomPosition, opts: FindPathOpts): FindPathResult;
+    findPathTo(pos: RoomPosition, opts: FindPathOpts): PathStep[];
     toJSON(): {
       id: string;
       x: number;

--- a/@types/game/utils.d.ts
+++ b/@types/game/utils.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 declare module "game/utils" {
-  import { FindPathOpts, FindPathResult, Id, RoomObject, RoomPosition, TERRAIN_SWAMP, TERRAIN_WALL } from "game";
+  import { FindPathOpts, PathStep, Id, RoomObject, RoomPosition, TERRAIN_SWAMP, TERRAIN_WALL } from "game";
   import { _Constructor } from "game/prototypes";
 
   // TODO: fix types
@@ -43,7 +43,7 @@ declare module "game/utils" {
    * ignore: array (objects which should be treated as obstacles during the search)
    * Any options supported by searchPath method
    */
-  export function findPath(fromPos: RoomPosition, toPos: RoomPosition, opts?: FindPathOpts): FindPathResult;
+  export function findPath(fromPos: RoomPosition, toPos: RoomPosition, opts?: FindPathOpts): PathStep[];
 
   /**
    * Get linear range between two objects. a and b may be any object containing x and y properties.


### PR DESCRIPTION
Fix: `findPath()` and `RoomObject.findPath()` both return results as a `PathStep[]` array rather than a `FindPathResult`
* https://github.com/screepers/screeps-arena-typescript-starter/blob/7c7ae1cbc70cf73231d5afa21a36d2bc80d4751b/exported-game-constants.js#L534

The `searchPath` is typed correctly and does return a `FindPathResult` object