### PR TITLE
Updating typescript and related packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "@types/screeps-arena": "screepers/typed-screeps-arena#develop",
     "@types/sinon": "^5.0.5",
     "@types/sinon-chai": "^3.2.0",
-    "@typescript-eslint/eslint-plugin": "^3.7.0",
-    "@typescript-eslint/parser": "^3.7.0",
-    "@typescript-eslint/typescript-estree": "^3.7.0",
+    "@typescript-eslint/eslint-plugin": "^5.18.0",
+    "@typescript-eslint/parser": "^5.18.0",
+    "@typescript-eslint/typescript-estree": "^5.18.0",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
@@ -56,12 +56,12 @@
     "rollup": "^2.6.1",
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-screeps": "^1.0.0",
-    "rollup-plugin-typescript2": "^0.27.0",
+    "rollup-plugin-typescript2": "^0.31.2",
     "sinon": "^6.3.5",
     "sinon-chai": "^3.2.0",
-    "ts-node": "^8.8.2",
+    "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.6.3"
   },
   "dependencies": {
     "source-map": "~0.6.1"


### PR DESCRIPTION
Fixes #20 

I tested this with the build alone, and that seemed to work; the unit tests have not been updated for Arena and do not run.